### PR TITLE
Code refactor and organizational names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,31 +81,39 @@ or ipfix collector written in Python. Netflow v5 is pretty simple and I was
 able to find a few examples already written to tweak. Who knows, maybe at some
 point I'll fill the gap.
 
-The AS lookup is performed using the pyasn library which uses a view from local
-file to map prefixes to ASN's.
+--
 
-Since it's 'only' a 12MB file, I decided to leave it watched by git in the
-repo. If you notice error where some prefixes aren't being looked up properly,
-it's probably due to this file being out of date.
+There are two offline databases that may need updating from time to time. These
+were chose to greatly speed up lookups and not to bog down other people's
+services.
 
-I've provided a script to update it for you so just get a fresh clone of the
-repo and run ``install_pyasn_db.sh``. You shouldn't have to do this, but if
-overwriting the current file makes git unwatch it run ``git add .`` otherwise
-setuptools-git won't add it to the package.
+First is the database used by the pyasn module. This is a converted version of
+a RiB snapshot taken from a looking glass. It's about 12MB and maps AS to IP
+prefixes.
+
+Second is the MaxMind Organizational CSV. This one maps AS to Org names and is
+about 12MB as well unzipped.
+
+To update these files, the easiest way is to just reinstall by grabbing the
+repo again and making sure you have git install as well as ``unzip``. Then
+before installing with pip, run the ``update-databases.sh`` script. This will
+download and convert/extract both databases and then add them to git repo so
+setuptools notices them.
+
+--
+
+The main object ``asn_report`` is a custom class ``ASNLookup`` that glues
+together a lot of these for easy back and forth.
 
 As of right now, the DB schema looks like:
 
 +------------+---------------------------------------------+
 | ASN        | AS advertising prefix                       |
 +------------+---------------------------------------------+
-| Owner      | Name of Owner (currently not implemented)   |
+| Owner      | Name of Owner                               |
 +------------+---------------------------------------------+
 | Host       | /32 host that packet was destined to        |
 +------------+---------------------------------------------+
 | Parent_pfx | Parent prefix of the host which is actually |
 |            | being advertised.                           |
 +------------+---------------------------------------------+
-
-AS owner/org_name isn't implemented yet because I didn't want to bombard any
-whois/cymru's txt record dns service for every single packet. Currently every
-packet fills that column with "NotImplemented".

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,17 @@ To start the webserver to easily look at summary of the data::
 
 That should spawn a local webserver reachable via http://localhost:5000/
 
+For the graphing, you have the option to display each AS the following ways:
+
+1. AS[num]. This is the default way.
+
+2. AS[num]: [owner_string]. This is what I called 'display name'. To enable
+   this provide ``--display-name`` as the only argument to ``asn_report``
+
+3. [owner_string]. I assumed that the display name could get pretty long so 
+   this final option is if you just want the name to show without the AS. To
+   enable it, provide ``--owner`` as the only argument to ``asn_report``
+
 Side Notes
 ----------
 

--- a/asn_report/asn_capture.py
+++ b/asn_report/asn_capture.py
@@ -27,19 +27,13 @@ Options:
 """
 
 import sys
-import pyasn
-import asn_report
-from os import path
 from docopt import docopt
 from sqlalchemy.exc import OperationalError
 from IPy import IP
 from scapy.all import sniff
 from asn_report.main import db
 from asn_report.models import ASNCount
-
-asn_db_path = path.abspath(
-        path.join(path.dirname(asn_report.__file__), 'resources/ip_to_asn.db'))
-asn_db = pyasn.pyasn(asn_db_path)
+from asn_report.lookup import ASNLookup
 
 
 class IPHeader(object):
@@ -47,6 +41,7 @@ class IPHeader(object):
     def __init__(self, saddr, daddr):
         self.src = saddr
         self.dst = daddr
+
 
 class Packet(object):
     '''Class to very minimally imitate scapy's packet structure
@@ -67,19 +62,22 @@ class Packet(object):
         self.protocol = protocol
         ip_header = IPHeader(saddr, daddr)
         self.headers = {
-                'IP': ip_header
+            'IP': ip_header
         }
+
     def __getitem__(self, key):
         return self.headers[key]
+
     def summary(self):
         '''Print packet summary'''
         keys = {
-                'proto': self.protocol,
-                'saddr': self.saddr,
-                'daddr': self.daddr,
-                'sport': self.sport,
-                'dport': self.dport,
+            'proto': self.protocol,
+            'saddr': self.saddr,
+            'daddr': self.daddr,
+            'sport': self.sport,
+            'dport': self.dport,
         }
+
         print '{proto} {saddr}:{sport} > {daddr}:{dport}'.format(**keys)
 
 
@@ -101,9 +99,8 @@ def netflow_v5_capture(host='0.0.0.0', port=2303, callback=None):
 
     '''
 
-
-    import socket, struct
-    from socket import inet_ntoa
+    import socket
+    import struct
 
     # Verify ``host`` is a valid IP address
     try:
@@ -120,29 +117,29 @@ def netflow_v5_capture(host='0.0.0.0', port=2303, callback=None):
     while True:
         buf, addr = sock.recvfrom(1500)
 
-        (version, count) = struct.unpack('!HH',buf[0:4])
+        (version, count) = struct.unpack('!HH', buf[0:4])
         if version != 5:
             print "Not NetFlow v5!"
             continue
 
-        # It's pretty unlikely you'll ever see more then 1000 records in a 
+        # It's pretty unlikely you'll ever see more then 1000 records in a
         # 1500 byte UDP packet
         if count <= 0 or count >= 1000:
             print "Invalid count %s" % count
             continue
 
-        uptime = socket.ntohl(struct.unpack('I',buf[4:8])[0])
-        epochseconds = socket.ntohl(struct.unpack('I',buf[8:12])[0])
+        uptime = socket.ntohl(struct.unpack('I', buf[4:8])[0])
+        epochseconds = socket.ntohl(struct.unpack('I', buf[8:12])[0])
 
         for i in range(0, count):
             try:
                 base = SIZE_OF_HEADER+(i*SIZE_OF_RECORD)
 
-                data = struct.unpack('!IIIIHH',buf[base+16:base+36])
+                data = struct.unpack('!IIIIHH', buf[base+16:base+36])
 
                 nfdata = {}
-                nfdata['saddr'] = inet_ntoa(buf[base+0:base+4])
-                nfdata['daddr'] = inet_ntoa(buf[base+4:base+8])
+                nfdata['saddr'] = socket.inet_ntoa(buf[base+0:base+4])
+                nfdata['daddr'] = socket.inet_ntoa(buf[base+4:base+8])
                 nfdata['pcount'] = data[0]
                 nfdata['bcount'] = data[1]
                 nfdata['stime'] = data[2]
@@ -154,11 +151,11 @@ def netflow_v5_capture(host='0.0.0.0', port=2303, callback=None):
                 continue
 
         packet = Packet(
-                nfdata['saddr'],
-                nfdata['daddr'],
-                nfdata['sport'],
-                nfdata['dport'],
-                nfdata['protocol']
+            nfdata['saddr'],
+            nfdata['daddr'],
+            nfdata['sport'],
+            nfdata['dport'],
+            nfdata['protocol']
             )
         if callback:
             # If anything is returned, print to stdout
@@ -225,19 +222,21 @@ def parse_packet(packet):
     # This will verify public IP before AS lookup. Flask view won't handle
     # None as AS currently.
     if IP(dst_ip).iptype() is 'PUBLIC':
-        dst_asn, dst_pfx = asn_db.lookup(dst_ip)
+        dst = ASNLookup(ipaddr=dst_ip)
+        dst_asn = dst.asnum
+        dst_pfx = dst.parent_pfx
+        dst_owner = dst.orgname
 
-        # Make sure that None doesn't get returned if db out of date
-        if dst_asn is None:
-            dst_asn = '00000'
-            owner = "IPtoASN Error"
-        else:
-            # Need to implement AS whois in a way that won't get flagged for
-            # too many requests
-            owner = 'NotImplemented'
-        args = (dst_asn, owner, dst_ip, dst_pfx)
+        # ASN should always be returned as int. If not, is error message
+        if not isinstance(dst_asn, int):
+            dst_asn = 00000
+            dst_owner = "IPtoASN Error"
+
+        args = (dst_asn, dst_owner, dst_ip, dst_pfx)
         add_to_sql(*args)
         return "AS%d owned by %s: %s child of %s" % args
+    else:
+        return "[WARNING]: AS-lookup failed for IP: %s" % dst_ip
 
 
 def main():

--- a/asn_report/lookup.py
+++ b/asn_report/lookup.py
@@ -103,7 +103,8 @@ class ASNLookup(object):
                                    path.dirname(asn_report.__file__),
                                    'resources/GeoIPASNum2.csv'))
         with open(org_db_path) as f:
-            raw_db = f.read()
+            # Read in as unicode to allow for non-Latin orgnames
+            raw_db = f.read().decode('utf-8')
         org_directory = {}
         for line in raw_db.splitlines():
             # Reference line:
@@ -115,7 +116,7 @@ class ASNLookup(object):
             try:
                 asn, owner = asn_and_owner.split(' ', 1)  # Sep AS and Org
             except ValueError:
-                asn, owner = (asn_and_owner, 'NoOrgAssociated')
+                asn, owner = (asn_and_owner, u'NoOrgAssociated')
             org_directory.update({asn: owner})
         return org_directory
 

--- a/asn_report/lookup.py
+++ b/asn_report/lookup.py
@@ -1,0 +1,155 @@
+import pyasn
+import asn_report
+from os import path
+
+'''
+TODO: Convert to unicode
+'''
+
+
+class reify(object):
+    """ Use as a class method decorator.  It operates almost exactly like the
+    Python ``@property`` decorator, but it puts the result of the method it
+    decorates into the instance dict after the first call, effectively
+    replacing the function it decorates with an instance variable.  It is, in
+    Python parlance, a non-data descriptor.  An example:
+
+    .. code-block:: python
+
+       class Foo(object):
+           @reify
+           def jammy(self):
+               print('jammy called')
+               return 1
+
+    And usage of Foo:
+
+    >>> f = Foo()
+    >>> v = f.jammy
+    'jammy called'
+    >>> print(v)
+    1
+    >>> f.jammy
+    1
+    >>> # jammy func not called the second time; it replaced itself with 1
+    """
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+        try:
+            self.__doc__ = wrapped.__doc__
+        except:  # pragma: no cover
+            pass
+
+    def __get__(self, inst, objtype=None):
+        if inst is None:
+            return self
+        val = self.wrapped(inst)
+        setattr(inst, self.wrapped.__name__, val)
+        return val
+
+
+class ASNLookup(object):
+
+    def __init__(self, ipaddr=None, asnum=None, orgname=None):
+        '''Central ASNLookup class. Instatiate with 1 of 3 values.
+
+        :param ipaddr: IP address to lookup
+        :type ipaddr: str
+        :param asnum: ASN to lookup
+        :type asnum: int
+        :param orgname: Organizational name as registered in whois
+        :type orgname: str
+
+        Usage is much like::
+
+            >>> lookup = ASNLookup(ipaddr='8.8.8.8')
+            >>> lookup.ipaddr
+            '8.8.8.8'
+            >>> lookup.parent_pfx
+            '8.8.8.0/24'
+            >>> lookup.asnum
+            15169
+            >>> lookup.orgname
+            'Google Inc.'
+
+        '''
+
+        if (None, None, None) == (ipaddr, asnum, orgname):
+            raise ValueError('At least one value must be provided for lookup!')
+
+        self.data = {'ipaddr': ipaddr,
+                     'asnum': asnum,
+                     'orgname': orgname,
+                     'parent_pfx': None}
+
+    def __getattr__(self, attr):
+        if self.data[attr] is None:
+            self.data[attr] = self._lookup(attr)
+            return self.data[attr]
+        return self.data[attr]
+
+    @reify
+    def _pyasn_db(self):
+        '''Return pyasn object after instantiating.'''
+        asn_db_path = path.abspath(path.join(
+                                   path.dirname(asn_report.__file__),
+                                   'resources/ip_to_asn.db'))
+        return pyasn.pyasn(asn_db_path)
+
+    @reify
+    def _maxmind_org_db(self):
+        '''Return CSV contents for Maxmind ASN database'''
+        org_db_path = path.abspath(path.join(
+                                   path.dirname(asn_report.__file__),
+                                   'resources/GeoIPASNum2.csv'))
+        with open(org_db_path) as f:
+            raw_db = f.read()
+        org_directory = {}
+        for line in raw_db.splitlines():
+            # Reference line:
+            # 16777216,16777471,"AS15169 Google Inc."
+            # Not all lines may have a name associated, so gotta try..expect it
+            line_split = line.split(',')  # Split CSV
+            asn_and_owner = line_split[2].strip('"')  # Strip double-quotes
+            # Catch AS without org name associated
+            try:
+                asn, owner = asn_and_owner.split(' ', 1)  # Sep AS and Org
+            except ValueError:
+                asn, owner = (asn_and_owner, 'NoOrgAssociated')
+            org_directory.update({asn: owner})
+        return org_directory
+
+    def _lookup(self, keyword):
+        '''Return value of _lookup_X() where X is ipaddr, asnum, or orgname.'''
+        return self.__getattribute__('_lookup_' + keyword)()
+
+    def _lookup_ipaddr(self):
+        raise NotImplemented('Not implemented yet to get IP from other values')
+
+    def _lookup_asnum(self):
+        '''Perform ASN lookup'''
+
+        asnum = self._pyasn_db.lookup(self.ipaddr)[0]
+        if asnum is None:  # If successful, will return int. If fail, str
+            return 'AS lookup failed: %s' % self.ipaddr
+
+        return asnum
+
+    def _lookup_parent_pfx(self):
+        '''Perform parent prefix lookup'''
+
+        pfx = self._pyasn_db.lookup(self.ipaddr)[1]
+        if pfx is None:
+            return 'Prefix lookup failed: %s' % self.ipaddr
+
+        return pfx
+
+    def _lookup_orgname(self):
+        '''Perform Organization Name lookup
+
+        Requires asnum to be available. If hasn't been looked up yet, the below
+        calling of `self.asnum` will go to `self.__getattr__` and look it up
+        before continuing.
+        '''
+
+        return self._maxmind_org_db['AS%d' % self.asnum]

--- a/asn_report/lookup.py
+++ b/asn_report/lookup.py
@@ -1,3 +1,4 @@
+import codecs
 import pyasn
 import asn_report
 from os import path
@@ -102,9 +103,9 @@ class ASNLookup(object):
         org_db_path = path.abspath(path.join(
                                    path.dirname(asn_report.__file__),
                                    'resources/GeoIPASNum2.csv'))
-        with open(org_db_path) as f:
-            # Read in as unicode to allow for non-Latin orgnames
-            raw_db = f.read().decode('utf-8')
+        # Read in as unicode to allow for non-Latin orgnames
+        with codecs.open(org_db_path, 'r', 'iso-8859-1') as f:
+            raw_db = f.read()
         org_directory = {}
         for line in raw_db.splitlines():
             # Reference line:

--- a/asn_report/models.py
+++ b/asn_report/models.py
@@ -1,4 +1,4 @@
-from asn_report.main import app, db
+from asn_report.main import db
 
 
 class ASNCount(db.Model):
@@ -8,12 +8,14 @@ class ASNCount(db.Model):
     owner = db.Column(db.String(128))
     host = db.Column(db.String(128), nullable=False)
     parent_pfx = db.Column(db.String(128), nullable=False)
+    display_name = db.Column(db.String(256))
 
     def __init__(self, asn, owner, host, parent_pfx):
         self.asn = asn
         self.owner = owner
         self.host = host
         self.parent_pfx = parent_pfx
+        self.display_name = 'AS%d: %s' % (self.asn, self.owner)
 
     def __repr__(self):
         return '<AS%d %s>' % (self.asn, self.owner)

--- a/asn_report/templates/asn.html
+++ b/asn_report/templates/asn.html
@@ -33,6 +33,7 @@
         } 
     %}
 
+    <p>{{ asn_data }}</p>
 </body>
 
 </html>

--- a/asn_report/views.py
+++ b/asn_report/views.py
@@ -1,3 +1,5 @@
+import sys
+import unicodedata
 from collections import Counter
 from flask import render_template
 from asn_report.models import ASNCount
@@ -5,6 +7,32 @@ from asn_report.models import ASNCount
 
 def asn():
     asn_rows = ASNCount.query.all()
-    counter = Counter([row.asn for row in asn_rows])
-    graph = [['AS'+str(asn), count] for asn, count in counter.iteritems()]
+
+    try:
+        sys.argv[1]
+    except IndexError:  # If no option provided, default to showing just asnum
+        counter = Counter([row.asn for row in asn_rows])
+        graph = [['AS'+str(asn), cnt] for asn, cnt in counter.iteritems()]
+        return render_template('asn.html', asn_data=graph)
+
+    # Chart with combined ASnum and owner string as data labels
+    if sys.argv[1] == '--display-name':
+        counter = Counter([row.display_name for row in asn_rows])
+        graph = [[norm(display), cnt] for display, cnt in counter.iteritems()]
+
+    # Chart with only owner string as the data labels
+    elif sys.argv[1] == '--owner':
+        counter = Counter([row.owner for row in asn_rows])
+        graph = [[norm(org), cnt] for org, cnt in counter.iteritems()]
+
+    else:  # If provided arg is neither, default back to just asnum
+        counter = Counter([row.asn for row in asn_rows])
+        graph = [['AS'+str(asn), cnt] for asn, cnt in counter.iteritems()]
+
     return render_template('asn.html', asn_data=graph)
+
+
+def norm(uni_str):
+    '''Normalizes unicode string'''
+
+    return unicodedata.normalize('NFKD', uni_str).encode('ascii', 'ignore')

--- a/install_pyasn_db.sh
+++ b/install_pyasn_db.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-pyasn_util_download.py --latest && \
-    pyasn_util_convert.py --single rib.*bz2 ./asn_report/resources/ip_to_asn.db

--- a/update-databases.sh
+++ b/update-databases.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+RESOURCES=./asn_report/resources
+GEOIP_FILE=GeoIPASNum2.csv
+PYASN_FILE=ip_to_asn.db
+PYASN_PATH=$RESOURCES/$PYASN_FILE
+GEOIP_PATH=$RESOURCES/$GEOIP_FILE
+
+pyasn_util_download.py --latest && \
+    pyasn_util_convert.py --single rib.*bz2 $PYASN_PATH
+
+curl -L \
+    http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip\
+    > GeoIPASNum2-tmp.zip && unzip GeoIPASNum2-tmp.zip \
+                                    -d $RESOURCES/
+rm GeoIPASNum2-tmp.zip
+git add $PYASN_PATH
+git add $GEOIP_PATH


### PR DESCRIPTION
#### Description

This PR from `develop` adds some features:
- Organizational string associated with ASNum will be stored in database encoding with iso-8859-1 to preserve original names (though it's normalized in the frontend)
- There are now three options for rendering the reports:
  1. The normal way, displaying data labels like AS15169
  2. Making the data labels be the organizational name, like Google Inc.
  3. Combining them into a "display name" like AS15169: Google Inc.
  
  These are controlled by passing no argument, `--owner`, and `--display-name` as arguments to `asn_report`.

In addition, this also refactors and cleans up some code. Specifically it adds the class `ASNLookup` which transparently glues together maxmind org lookup and ip to asn lookup into a nice interface. This allows in code to do something like:

``` python

>>> lookup = ASNLookup(ipaddr='8.8.8.8')
>>> lookup.orgname
'Google Inc.'
>>> lookup.asnum
15169
>>> lookup.parent_pfx
'8.8.8.0/24'
```
