### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/update-databases.sh
+++ b/update-databases.sh
@@ -10,7 +10,7 @@ pyasn_util_download.py --latest && \
     pyasn_util_convert.py --single rib.*bz2 $PYASN_PATH
 
 curl -L \
-    http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip\
+    https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip\
     > GeoIPASNum2-tmp.zip && unzip GeoIPASNum2-tmp.zip \
                                     -d $RESOURCES/
 rm GeoIPASNum2-tmp.zip


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).